### PR TITLE
Added another input argument in tarring script

### DIFF
--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -23,7 +23,7 @@ from enum import Enum
 from functools import total_ordering
 from pathlib import Path
 from typing import Dict, List, Optional, Union
-
+import os
 import hydra
 import wrapt
 from omegaconf import DictConfig, OmegaConf
@@ -663,12 +663,15 @@ class Model(Typing, Serialization, FileIO):
             )
         filename = location_in_the_cloud.split("/")[-1]
         url = location_in_the_cloud.replace(filename, "")
-        cache_dir = Path.joinpath(Path.home(), f'.cache/torch/NeMo/NeMo_{nemo.__version__}/{filename[:-5]}')
+        if os.getenv('NEMO_CACHE_DIR') is not None and os.path.isdir(os.getenv('NEMO_CACHE_DIR')):
+            cache_dir = Path.joinpath(Path(os.getenv('NEMO_CACHE_DIR')), f'.cache/torch/NeMo/NeMo_{nemo.__version__}/{filename[:-5]}')
+        else:
+            cache_dir = Path.joinpath(Path.home(), f'.cache/torch/NeMo/NeMo_{nemo.__version__}/{filename[:-5]}')
         # If either description and location in the cloud changes, this will force re-download
-        cache_subfolder = hashlib.md5((location_in_the_cloud + description).encode('utf-8')).hexdigest()
+        #cache_subfolder = hashlib.md5((location_in_the_cloud + description).encode('utf-8')).hexdigest()
         # if file exists on cache_folder/subfolder, it will be re-used, unless refresh_cache is True
         nemo_model_file_in_cache = maybe_download_from_cloud(
-            url=url, filename=filename, cache_dir=cache_dir, subfolder=cache_subfolder, refresh_cache=refresh_cache
+            url=url, filename=filename, cache_dir=cache_dir, subfolder=None, refresh_cache=refresh_cache
         )
         logging.info("Instantiating model from pre-trained checkpoint")
         if class_ is None:

--- a/scripts/speech_recognition/convert_to_tarred_audio_dataset.py
+++ b/scripts/speech_recognition/convert_to_tarred_audio_dataset.py
@@ -25,6 +25,7 @@
 
 python convert_to_tarred_audio_dataset.py \
     --manifest_path=<path to the manifest file> \
+    --dataset_dir=<dataset directory path> \
     --target_dir=<path to output directory> \
     --num_shards=<number of tarfiles that will contain the audio>
     --max_duration=<float representing maximum duration of audio samples> \
@@ -75,6 +76,10 @@ parser = argparse.ArgumentParser(
 )
 parser.add_argument(
     "--manifest_path", default=None, type=str, required=False, help="Path to the existing dataset's manifest."
+)
+
+parser.add_argument(
+    "--dataset_dir", default=None, type=str, required=False, help="Path to the dataset's directory."
 )
 
 parser.add_argument(
@@ -473,7 +478,7 @@ class ASRTarredDatasetBuilder:
             base = base.replace('.', '_')
             squashed_filename = f'{base}{ext}'
             if squashed_filename not in count:
-                tar.add(entry['audio_filepath'], arcname=squashed_filename)
+                tar.add(os.path.join(args.dataset_dir,entry['audio_filepath']), arcname=squashed_filename)
 
             if 'label' in entry:
                 base, ext = os.path.splitext(squashed_filename)


### PR DESCRIPTION
The newly added argument(dataset_dir) is concatenated with the path obtained from the manifest file. This solves the problem of FileNotFoundError as an absolute path is given for the datasets.