### PR TITLE
Pin huggingface_hub version to match with main branch

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-huggingface_hub
+huggingface_hub>=0.20.3,<0.24.0
 numba
 numpy>=1.22,<1.24
 onnx>=1.7.0


### PR DESCRIPTION
# What does this PR do ?

Pin huggingface_hub version to match with main branch to avoid `ImportError: cannot import name 'ModelFilter' from 'huggingface_hub'`. See https://github.com/NVIDIA/NeMo/issues/9793